### PR TITLE
GamingMode: Increase floating button opacity when hiding

### DIFF
--- a/app/src/main/java/org/exthmui/game/services/OverlayService.java
+++ b/app/src/main/java/org/exthmui/game/services/OverlayService.java
@@ -63,7 +63,7 @@ public class OverlayService extends Service {
     private static final int FLOATING_BUTTON_HIDE_DELAY = 1000;
 
     /** Default alpha value for hiding the floating button hidden */
-    private static final float FLOATING_BUTTON_HIDE_ALPHA = 0.1f;
+    private static final float FLOATING_BUTTON_HIDE_ALPHA = 0.5f;
 
     private View mGamingFloatingLayout;
     private ImageView mGamingFloatingButton;


### PR DESCRIPTION
* In some too light scenarios, visibility of the floating button is lost, so increasing the visibility a bit helps.